### PR TITLE
Add error handlers and tests

### DIFF
--- a/01_web_app/app.py
+++ b/01_web_app/app.py
@@ -1,10 +1,37 @@
-from flask import Flask
+"""Minimal Flask application with basic error handling."""
 
-app = Flask(__name__)
+from flask import Flask, jsonify
 
-@app.route('/')
-def home():
-    return 'Hello Codex'
 
-if __name__ == '__main__':
+def create_app() -> Flask:
+    """Create and configure the Flask application."""
+    app = Flask(__name__)
+
+    @app.route('/')
+    def home() -> str:
+        """Root route returning a friendly greeting."""
+        return 'Hello Codex'
+
+    @app.route('/error')
+    def trigger_error() -> None:  # pragma: no cover - used only for tests
+        """Route used in tests to simulate an internal error."""
+        raise RuntimeError('Intentional error')
+
+    @app.errorhandler(404)
+    def not_found(error):
+        """Return a JSON 404 error response."""
+        return jsonify({'error': 'Not Found'}), 404
+
+    @app.errorhandler(Exception)
+    def internal_error(error):
+        """Return a JSON 500 error response for unhandled exceptions."""
+        app.logger.exception(error)
+        return jsonify({'error': 'Internal Server Error'}), 500
+
+    return app
+
+
+app = create_app()
+
+if __name__ == '__main__':  # pragma: no cover - manual execution
     app.run(debug=True)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 Flask
+pytest

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,0 +1,31 @@
+from importlib import import_module
+from pathlib import Path
+
+import pytest
+
+# Add the 01_web_app directory to sys.path so we can import app
+import sys
+APP_DIR = Path(__file__).resolve().parents[1] / "01_web_app"
+sys.path.insert(0, str(APP_DIR))
+
+app_module = import_module("app")
+app = app_module.create_app()
+
+@pytest.fixture()
+def client():
+    with app.test_client() as client:
+        yield client
+
+
+def test_404_returns_json(client):
+    response = client.get("/nonexistent")
+    assert response.status_code == 404
+    data = response.get_json()
+    assert data == {"error": "Not Found"}
+
+
+def test_500_returns_json(client):
+    response = client.get("/error")
+    assert response.status_code == 500
+    data = response.get_json()
+    assert data == {"error": "Internal Server Error"}


### PR DESCRIPTION
## Summary
- improve Flask app structure with create_app
- add JSON 404 and 500 error handlers
- add route to trigger errors for testing
- add pytest tests covering 404 and 500 cases

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6887bbcda6748328ad26cdd4e5f12464