### PR TITLE
Implement file upload endpoint with validation

### DIFF
--- a/01_web_app/app.py
+++ b/01_web_app/app.py
@@ -1,11 +1,21 @@
 """Minimal Flask application with basic error handling."""
 
-from flask import Flask, jsonify
+from pathlib import Path
+
+from flask import Flask, jsonify, request
+from werkzeug.exceptions import RequestEntityTooLarge
+
+from exceptions import ValidationError
+from services.file_service import save_file
+
+
+UPLOAD_DIR = Path(__file__).resolve().parents[1] / "uploads"
 
 
 def create_app() -> Flask:
     """Create and configure the Flask application."""
     app = Flask(__name__)
+    app.config["MAX_CONTENT_LENGTH"] = 5 * 1024 * 1024  # 5 MB
 
     @app.route('/')
     def home() -> str:
@@ -16,6 +26,24 @@ def create_app() -> Flask:
     def trigger_error() -> None:  # pragma: no cover - used only for tests
         """Route used in tests to simulate an internal error."""
         raise RuntimeError('Intentional error')
+
+    @app.route('/upload', methods=['POST'])
+    def upload():
+        """Handle file upload requests."""
+        app.logger.info("Upload attempt")
+        try:
+            save_file(request.files.get('file'), UPLOAD_DIR)
+        except ValidationError as exc:
+            app.logger.warning("Upload failed: %s", exc)
+            return jsonify({'error': str(exc)}), 400
+        app.logger.info("Upload succeeded")
+        return jsonify({'message': 'File uploaded successfully'}), 201
+
+    @app.errorhandler(RequestEntityTooLarge)
+    def file_too_large(error):
+        """Return a JSON 413 error when the uploaded file is too large."""
+        app.logger.warning("Upload failed: file too large")
+        return jsonify({'error': 'File too large'}), 413
 
     @app.errorhandler(404)
     def not_found(error):

--- a/01_web_app/exceptions.py
+++ b/01_web_app/exceptions.py
@@ -1,0 +1,5 @@
+class ValidationError(Exception):
+    """Exception raised for validation errors in the application."""
+
+
+__all__ = ["ValidationError"]

--- a/01_web_app/services/file_service.py
+++ b/01_web_app/services/file_service.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Optional
+
+from werkzeug.datastructures import FileStorage
+from werkzeug.utils import secure_filename
+
+from exceptions import ValidationError
+
+ALLOWED_EXTENSIONS = {".csv", ".pdf"}
+MAX_FILE_SIZE = 5 * 1024 * 1024  # 5 MB
+
+
+def save_file(file: Optional[FileStorage], upload_dir: Path) -> str:
+    """Validate and save an uploaded file.
+
+    Args:
+        file: The uploaded file from the request.
+        upload_dir: Directory where the file should be saved.
+
+    Returns:
+        The filename of the saved file.
+
+    Raises:
+        ValidationError: If validation fails.
+    """
+    if file is None or file.filename == "":
+        raise ValidationError("No file provided")
+
+    filename = secure_filename(file.filename)
+    ext = Path(filename).suffix.lower()
+    if ext not in ALLOWED_EXTENSIONS:
+        raise ValidationError("Unsupported file type")
+
+    file.seek(0, 2)  # move to end of file
+    size = file.tell()
+    file.seek(0)
+    if size > MAX_FILE_SIZE:
+        raise ValidationError("File too large")
+
+    upload_dir.mkdir(parents=True, exist_ok=True)
+    filepath = upload_dir / filename
+    file.save(filepath)
+    return filename

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -2,6 +2,7 @@ from importlib import import_module
 from pathlib import Path
 
 import pytest
+import io
 
 # Add the 01_web_app directory to sys.path so we can import app
 import sys
@@ -29,3 +30,28 @@ def test_500_returns_json(client):
     assert response.status_code == 500
     data = response.get_json()
     assert data == {"error": "Internal Server Error"}
+
+
+def test_upload_accepts_csv(client):
+    data = {"file": (io.BytesIO(b"a,b\n1,2"), "test.csv")}
+    response = client.post("/upload", data=data, content_type="multipart/form-data")
+    assert response.status_code == 201
+    assert response.get_json() == {"message": "File uploaded successfully"}
+    uploaded = Path("uploads") / "test.csv"
+    assert uploaded.exists()
+    uploaded.unlink()
+
+
+def test_upload_rejects_unsupported_type(client):
+    data = {"file": (io.BytesIO(b"data"), "test.txt")}
+    response = client.post("/upload", data=data, content_type="multipart/form-data")
+    assert response.status_code == 400
+    assert response.get_json() == {"error": "Unsupported file type"}
+
+
+def test_upload_rejects_oversized_file(client):
+    big_content = b"a" * (5 * 1024 * 1024 + 1)
+    data = {"file": (io.BytesIO(big_content), "big.csv")}
+    response = client.post("/upload", data=data, content_type="multipart/form-data")
+    assert response.status_code == 413
+    assert response.get_json() == {"error": "File too large"}

--- a/uploads/.gitignore
+++ b/uploads/.gitignore
@@ -1,0 +1,2 @@
+*
+!/.gitignore


### PR DESCRIPTION
## Summary
- add `/upload` route to handle temporary file uploads with size and type checks
- introduce service layer and custom `ValidationError` for clean validation logic
- test uploading supported files, unsupported types, and oversized files

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688fa0ca9c3c8328a19c94c5435f1aa5